### PR TITLE
x-max: Define distances for extruder and gantry

### DIFF
--- a/definitions/x-max.def.json
+++ b/definitions/x-max.def.json
@@ -15,6 +15,18 @@
 		"machine_name": { "default_value": "X-MAX" },        
         "machine_width": { "default_value": 300 },
         "machine_depth": { "default_value": 250 },
+        "machine_head_with_fans_polygon":
+        {
+            "default_value": [
+                [-33, 55],
+                [-33, -55],
+                [44, 55],
+                [44, -55]
+            ]
+        },
+        "gantry_height": {
+            "value": "13"
+        },
         "machine_height": { "default_value": 300 }
     }
 }


### PR DESCRIPTION
@alkaes 

When using print sequence "one at the time" then cura needs the minimum gantry height and maximum extruder (x/y) distances from the nozzle. This information is used to inform the user when there might be  a collision between an already printed object.